### PR TITLE
Work around a crash with Industrial Foregoing fluid pumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,12 @@ repositories {
         name = "spongepowered"
         url = "https://repo.spongepowered.org/repository/maven-public"
     }
+    maven {
+        url "https://www.cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
 }
 
 dependencies {
@@ -154,6 +160,10 @@ dependencies {
     api("forestry:forestry_1.12.2:5.8.2.387")
     api("hearth-well:hwell:0.5.2")
     api("immersive-engineering:ImmersiveEngineering:0.12:92")
+    /* Industrial Foregoing 1.12.13-237 */
+    api("curse.maven:industrialforegoing-266515:2745321")
+    /* TeslaCoreLib (required by Industrial Foregoing) */
+    api("curse.maven:teslacorelib-254602:2891841")
     api("integrated-dynamics:IntegratedDynamics:1.12.2:1.1.7")
     api("journeymap:journeymap:1.12.2:5.7.0")
     api("kubejs-forge:KubeJS-forge:1.12.2:1.1.0.63")

--- a/src/main/java/io/github/lxgaming/sledgehammer/configuration/category/MixinCategory.java
+++ b/src/main/java/io/github/lxgaming/sledgehammer/configuration/category/MixinCategory.java
@@ -16,47 +16,7 @@
 
 package io.github.lxgaming.sledgehammer.configuration.category;
 
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ActuallyAdditionsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ArmorUnderMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.AstralSorceryMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.BDSMMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.BewitchmentMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.BiomesOPlentyMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.CareerBeesMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.CarryOnMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ChampionsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.CoreMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.DankNullMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.EnderIOMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.EnderStorageMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.FluxNetworksMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ForgeMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ImmersiveEngineeringMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.IntegratedDynamicsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.JourneyMapMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.KubeJSMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.LogisticsPipesMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.MatterOverdriveMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.MorphMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.MowziesMobsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.NaturesAuraMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.PrimitiveCraftingMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.PrimitiveMobsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ProjectRedMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.PyrotechMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.QMDMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.QuarkMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.RandomThingsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.RealFilingCabinetMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.RuinsMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.SpongeMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.StorageNetworkMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.ThaumicWondersMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.TombManyGravesMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.TopographyMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.TotemicMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.VaultopicMixinCategory;
-import io.github.lxgaming.sledgehammer.configuration.category.mixin.WolforceMixinCategory;
+import io.github.lxgaming.sledgehammer.configuration.category.mixin.*;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -110,6 +70,9 @@ public class MixinCategory {
     
     @Setting(value = "immersiveengineering", comment = "Immersive Engineering")
     private ImmersiveEngineeringMixinCategory immersiveEngineeringMixinCategory = new ImmersiveEngineeringMixinCategory();
+
+    @Setting(value = "industrialforegoing", comment = "IndustrialForegoing")
+    private IndustrialForegoingMixinCategory industrialForegoingMixinCategory = new IndustrialForegoingMixinCategory();
     
     @Setting(value = "integrateddynamics", comment = "Integrated Dynamics")
     private IntegratedDynamicsMixinCategory integratedDynamicsMixinCategory = new IntegratedDynamicsMixinCategory();
@@ -245,9 +208,13 @@ public class MixinCategory {
     public ForgeMixinCategory getForgeMixinCategory() {
         return forgeMixinCategory;
     }
-    
+
     public ImmersiveEngineeringMixinCategory getImmersiveEngineeringMixinCategory() {
         return immersiveEngineeringMixinCategory;
+    }
+
+    public IndustrialForegoingMixinCategory getIndustrialForegoingMixinCategory() {
+        return industrialForegoingMixinCategory;
     }
     
     public IntegratedDynamicsMixinCategory getIntegratedDynamicsMixinCategory() {

--- a/src/main/java/io/github/lxgaming/sledgehammer/configuration/category/mixin/IndustrialForegoingMixinCategory.java
+++ b/src/main/java/io/github/lxgaming/sledgehammer/configuration/category/mixin/IndustrialForegoingMixinCategory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Alex Thomson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.lxgaming.sledgehammer.configuration.category.mixin;
+
+import io.github.lxgaming.sledgehammer.configuration.annotation.Mapping;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class IndustrialForegoingMixinCategory {
+
+    @Mapping(value = "industrialforegoing.tile.world.FluidPumpTileMixin", dependencies = {"industrialforegoing"})
+    @Setting(value = "fluid-pump-null-crash", comment = "If 'true', fixes a crash related to a fluid not being present when the pump tries to pump.")
+    private boolean fluidPumpNullCrash = false;
+
+    public boolean isFluidPumpNullCrash() {
+        return fluidPumpNullCrash;
+    }
+}

--- a/src/main/java/io/github/lxgaming/sledgehammer/mixin/industrialforegoing/tile/world/FluidPumpTileMixin.java
+++ b/src/main/java/io/github/lxgaming/sledgehammer/mixin/industrialforegoing/tile/world/FluidPumpTileMixin.java
@@ -1,0 +1,63 @@
+package io.github.lxgaming.sledgehammer.mixin.industrialforegoing.tile.world;
+
+import com.buuz135.industrial.tile.world.FluidPumpTile;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import javax.annotation.Nullable;
+
+/**
+ * Used to prevent a NullPointerException on FluidPumpTile.java:101 (`handler` is null).
+ */
+class FakeFluidHandler implements IFluidHandler {
+    FakeFluidHandler() {
+
+    }
+    @Override
+    public IFluidTankProperties[] getTankProperties() {
+        return new IFluidTankProperties[0];
+    }
+
+    @Override
+    public int fill(FluidStack resource, boolean doFill) {
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        return null;
+    }
+}
+@Mixin(FluidPumpTile.class)
+public class FluidPumpTileMixin {
+    @Redirect(
+            method = "work",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraftforge/fluids/FluidUtil;getFluidHandler(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/EnumFacing;)Lnet/minecraftforge/fluids/capability/IFluidHandler;"
+            ),
+            remap = false
+    )
+    private IFluidHandler getFluidHandler(World world, BlockPos blockPos, @Nullable EnumFacing side) {
+        IFluidHandler handler = FluidUtil.getFluidHandler(world, blockPos, side);
+        if(handler != null)
+            return handler;
+        else
+            return new FakeFluidHandler();
+    }
+}

--- a/src/main/resources/mixins.sledgehammer.industrialforegoing.json
+++ b/src/main/resources/mixins.sledgehammer.industrialforegoing.json
@@ -1,0 +1,15 @@
+{
+  "required": false,
+  "minVersion": "0.7.10",
+  "package": "io.github.lxgaming.sledgehammer.mixin.industrialforegoing",
+  "refmap": "mixins.sledgehammer.refmap.json",
+  "plugin": "io.github.lxgaming.sledgehammer.mixin.plugin.CorePlugin",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "tile.world.FluidPumpTileMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
The original issue was that a NullPointerException occured on [this line](https://github.com/InnovativeOnlineIndustries/Industrial-Foregoing/blob/ff3afe62fcab65e4dcd8cca52ca31e6595a48cd8/src/main/java/com/buuz135/industrial/tile/world/FluidPumpTile.java#L101). My understanding of the Forge code is quite limited, but presumably there is some type of race condition where the pump expects fluid to be on that block, but it gets removed before the pump actually pumps from it.

The workaround I used here is to simply return a fake IFluidHandler that will get it past that line without crashing or pumping nonexistent fluid.  I'm not 100% sure if the pump will actually continue to keep pumping after this happens, but this behavior is still better than a full server crash.

I couldn't figure out how to get the right artifact name for CurseForge's Maven, so I used cursemaven.com instead. Pointers on how to do that would be appreciated. :slightly_smiling_face: 

Fixes InnovativeOnlineIndustries/Industrial-Foregoing#743
Fixes InnovativeOnlineIndustries/Industrial-Foregoing#673