### PR TITLE
Fix MC-88176 for 1.12.2

### DIFF
--- a/src/main/java/io/github/lxgaming/sledgehammer/configuration/category/mixin/CoreMixinCategory.java
+++ b/src/main/java/io/github/lxgaming/sledgehammer/configuration/category/mixin/CoreMixinCategory.java
@@ -111,6 +111,10 @@ public class CoreMixinCategory {
     @Mapping(value = "core.server.management.PlayerChunkMapMixin")
     @Setting(value = "player-chunk-map", comment = "If 'true', prevents ConcurrentModificationException in PlayerChunkMap.")
     private boolean playerChunkMap = false;
+
+    @Mapping(value = "core.client.RenderGlobalMixin")
+    @Setting(value = "premature-culling", comment = "If 'true', fixes MC-88176 (entities culled too aggresively at subchunk boundaries).")
+    private boolean prematureCulling = false;
     
     @Mapping(value = "core.world.WorldMixin_ChunkUnload")
     @Setting(value = "tile-entity-chunk-unload", comment = "If 'true', prevents unloading TileEntities from loading chunks")

--- a/src/main/java/io/github/lxgaming/sledgehammer/mixin/core/client/RenderGlobalMixin.java
+++ b/src/main/java/io/github/lxgaming/sledgehammer/mixin/core/client/RenderGlobalMixin.java
@@ -1,0 +1,34 @@
+package io.github.lxgaming.sledgehammer.mixin.core.client;
+
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.client.renderer.chunk.RenderChunk;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ClassInheritanceMultiMap;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.chunk.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin( value = RenderGlobal.class, priority = 1337)
+public class RenderGlobalMixin {
+    @Redirect( method = "setupTerrain", at = @At( value = "FIELD", target = "Lnet/minecraft/client/renderer/chunk/RenderChunk;boundingBox:Lnet/minecraft/util/math/AxisAlignedBB;"))
+    public AxisAlignedBB getBoundingBoxForChunk(RenderChunk renderChunk) {
+        // Fixes MC-88176 by checking the entity list for the subchunk and adjusting the bounding box as needed.
+        int subChunkYPos = renderChunk.getPosition().getY();
+        Chunk chunk = renderChunk.getWorld().getChunk(renderChunk.getPosition());
+        ClassInheritanceMultiMap<Entity> entityMap = chunk.getEntityLists()[subChunkYPos / 16];
+        double extraMaxY = 0;
+        if (!entityMap.isEmpty()) {
+            for (Entity entity : entityMap) {
+                AxisAlignedBB entityBox = entity.getRenderBoundingBox().grow(0.5d);
+                double height = entityBox.maxY - entityBox.minY;
+                double subChunkOffset = entity.getPosition().getY() - subChunkYPos;
+                extraMaxY = Math.max(extraMaxY, (subChunkOffset+height)-16);
+            }
+        }
+        AxisAlignedBB box = renderChunk.boundingBox;
+        box = new AxisAlignedBB(box.minX, box.minY, box.minZ, box.maxX, box.maxY + extraMaxY, box.maxZ);
+        return box;
+    }
+}

--- a/src/main/resources/mixins.sledgehammer.core.json
+++ b/src/main/resources/mixins.sledgehammer.core.json
@@ -37,7 +37,8 @@
   ],
   "client": [
     "client.MinecraftAccessor",
-    "client.MinecraftMixin"
+    "client.MinecraftMixin",
+    "client.RenderGlobalMixin"
   ],
   "server": [
     "server.management.PlayerChunkMapMixin",


### PR DESCRIPTION
Reproduction steps for vanilla bug:

1. Stand at Y=63 in a generally flat area.
2. Summon an iron golem: `/summon villager_golem ~ ~ ~ {NoAI:1}`
3. Stand one block away from the golem so that you are directly in front of/behind it.
4. Look straight at the golem.
5. Look straight up slowly.
6. Observe that the golem disappears at certain angles.

I considered implementing some sort of cache for the bounding box adjustment, but there is no visible FPS impact on my very weak machine, so I don't think it's necessary.